### PR TITLE
ci: add R CMD check GitHub Actions workflow

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,0 +1,31 @@
+name: R-CMD-check
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  R-CMD-check:
+    runs-on: ubuntu-latest
+
+    env:
+      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: check
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          error-on: '"error"'


### PR DESCRIPTION
This adds a minimal GitHub Actions workflow to run R CMD check on pull requests and pushes to master. This is a preparatory step before continuing the DS-np implementation in #5.

## What this adds

- `.github/workflows/R-CMD-check.yaml` — runs `R CMD check` on Ubuntu with R release
- Triggers on `pull_request` and `push` to `master`
- Uses `r-lib/actions` v2 for setup, dependencies (including Suggests), and check
- Enables R package caching via public RSPM
- Fails the workflow if `R CMD check` reports errors

## What this does NOT add

- No lintr, codecov, or pkgdown workflows
- No changes to R code, tests, or documentation